### PR TITLE
Update unofficial-ring-connect.groovy

### DIFF
--- a/src/apps/unofficial-ring-connect.groovy
+++ b/src/apps/unofficial-ring-connect.groovy
@@ -718,6 +718,7 @@ private getDEVICE_TYPES() {
 
     "hp_cam_v1": [name: "Ring Floodlight Cam", driver: "Ring Virtual Light with Siren", dingable: true],
     "hp_cam_v2": [name: "Ring Spotlight Cam Wired", driver: "Ring Virtual Light with Siren", dingable: true],
+    "spotlightw_v2": [name: "Ring Spotlight Cam Wired", driver: "Ring Virtual Light with Siren", dingable: true],
     "floodlight_v2": [name: "Ring Floodlight Cam Wired", driver: "Ring Virtual Light with Siren", dingable: true],
     "stickup_cam": [name: "Ring Original Stick Up Cam", driver: "Ring Virtual Camera", dingable: true],
     "stickup_cam_v3": [name: "Ring Stick Up Cam", driver: "Ring Virtual Camera", dingable: true],

--- a/src/apps/unofficial-ring-connect.groovy
+++ b/src/apps/unofficial-ring-connect.groovy
@@ -36,7 +36,7 @@
  *  2020-02-29: Chime Pro v2 support
  *              Removed session functionality since it's no longer needed
  *              Changed namespace
- *
+ *  2020-07-21: Added support for second version of Spotlight Wired Camera 
  *
  */
 


### PR DESCRIPTION
@cmorse - Please make sure you update to include "spotlight_v2" ... otherwise you are missing the new versions of the spotlight camera (nothing different from hp_cam_v2, but Ring has a new model number for it). The app won't discover these spotlight cameras without it!

![Screen Shot 2020-07-21 at 11 39 51 AM](https://user-images.githubusercontent.com/17929290/88082219-15f95600-cb47-11ea-8fed-a3e8a5983847.jpg)
